### PR TITLE
Nutrients checkbox bug

### DIFF
--- a/src/components/AddNutrientsModal.vue
+++ b/src/components/AddNutrientsModal.vue
@@ -33,7 +33,7 @@
               :key="item"
               class="border badge text-bg-light fs-6 m-1"
             >
-              {{ filteredNutrients[item] }}
+              {{ nutrients[item] }}
             </span>
           </div>
         </div>

--- a/src/components/AddNutrientsModal.vue
+++ b/src/components/AddNutrientsModal.vue
@@ -138,10 +138,10 @@ export default {
     },
     showModal(item) {
       this.product = { ...item }
+      this.addNutrients = []
       if (item.addNutrients) {
         this.addNutrients = item.addNutrients
       }
-
       this.modal.show()
     },
     hideModal() {

--- a/src/components/AddNutrientsModal.vue
+++ b/src/components/AddNutrientsModal.vue
@@ -96,13 +96,11 @@ export default {
   methods: {
     ...mapActions(useFoodStore, ['addMyProduct']),
     searchNutrient(nutrient) {
-      const data = []
-      Object.values(this.nutrients).filter(item => {
-        if (item.match(nutrient)) {
-          data.push(item)
-        }
-      })
-      this.filteredNutrients = data
+      this.filteredNutrients = Object.fromEntries(
+        Object.entries(this.nutrients).filter(([, value]) => {
+          return value.match(nutrient)
+        }),
+      )
     },
     updateFilterData() {
       const data = { ...this.headerChineseAndEnglish }


### PR DESCRIPTION
搜尋營養素後，再進行勾選，清空搜尋欄位後，顯示已新增品項會出現錯誤，變成index號碼
因此改為搜尋結果，仍必須呈現與一開始被搜尋的資料，同為物件型式